### PR TITLE
feat(storage): add support for custom object storage path prefix

### DIFF
--- a/core/storageproviders/rewriteLocalPlaylist.go
+++ b/core/storageproviders/rewriteLocalPlaylist.go
@@ -13,7 +13,7 @@ import (
 )
 
 // rewriteRemotePlaylist will take a local playlist and rewrite it to have absolute URLs to remote locations.
-func rewriteRemotePlaylist(localFilePath, remoteServingEndpoint string) error {
+func rewriteRemotePlaylist(localFilePath, remoteServingEndpoint, pathPrefix string) error {
 	f, err := os.Open(localFilePath) // nolint
 	if err != nil {
 		log.Fatalln(err)
@@ -25,7 +25,14 @@ func rewriteRemotePlaylist(localFilePath, remoteServingEndpoint string) error {
 	}
 
 	for _, item := range p.Variants {
-		item.URI = remoteServingEndpoint + filepath.Join("/hls", item.URI)
+		// Determine the final path to this playlist.
+		var finalPath string
+		if pathPrefix != "" {
+			finalPath = filepath.Join(pathPrefix, "/hls")
+		} else {
+			finalPath = "/hls"
+		}
+		item.URI = remoteServingEndpoint + filepath.Join(finalPath, item.URI)
 	}
 
 	publicPath := filepath.Join(config.HLSStoragePath, filepath.Base(localFilePath))

--- a/core/storageproviders/s3Storage.go
+++ b/core/storageproviders/s3Storage.go
@@ -37,6 +37,7 @@ type S3Storage struct {
 	s3AccessKey       string
 	s3Secret          string
 	s3ACL             string
+	s3PathPrefix      string
 	s3ForcePathStyle  bool
 
 	// If we try to upload a playlist but it is not yet on disk
@@ -73,6 +74,7 @@ func (s *S3Storage) Setup() error {
 	s.s3AccessKey = s3Config.AccessKey
 	s.s3Secret = s3Config.Secret
 	s.s3ACL = s3Config.ACL
+	s.s3PathPrefix = s3Config.PathPrefix
 	s.s3ForcePathStyle = s3Config.ForcePathStyle
 
 	s.sess = s.connectAWS()
@@ -107,6 +109,7 @@ func (s *S3Storage) SegmentWritten(localFilePath string) {
 	// so the segments and the HLS playlist referencing
 	// them are in sync.
 	playlistPath := filepath.Join(filepath.Dir(localFilePath), "stream.m3u8")
+
 	if _, err := s.Save(playlistPath, 0); err != nil {
 		s.queuedPlaylistUpdates[playlistPath] = playlistPath
 		if pErr, ok := err.(*os.PathError); ok {
@@ -133,7 +136,7 @@ func (s *S3Storage) VariantPlaylistWritten(localFilePath string) {
 // MasterPlaylistWritten is called when the master hls playlist is written.
 func (s *S3Storage) MasterPlaylistWritten(localFilePath string) {
 	// Rewrite the playlist to use absolute remote S3 URLs
-	if err := rewriteRemotePlaylist(localFilePath, s.host); err != nil {
+	if err := rewriteRemotePlaylist(localFilePath, s.host, s.s3PathPrefix); err != nil {
 		log.Warnln(err)
 	}
 }
@@ -150,6 +153,12 @@ func (s *S3Storage) Save(filePath string, retryCount int) (string, error) {
 	normalizedPath := strings.TrimPrefix(filePath, config.HLSStoragePath)
 	// Build the remote path by adding the "hls" path prefix.
 	remotePath := strings.Join([]string{"hls", normalizedPath}, "")
+
+	// If a custom path prefix is set prepend it.
+	if s.s3PathPrefix != "" {
+		prefix := strings.TrimPrefix(s.s3PathPrefix, "/")
+		remotePath = strings.Join([]string{prefix, remotePath}, "/")
+	}
 
 	maxAgeSeconds := utils.GetCacheDurationSecondsForPath(filePath)
 	cacheControlHeader := fmt.Sprintf("max-age=%d", maxAgeSeconds)

--- a/models/s3Storage.go
+++ b/models/s3Storage.go
@@ -11,6 +11,9 @@ type S3 struct {
 	ACL            string `json:"acl,omitempty"`
 	ForcePathStyle bool   `json:"forcePathStyle"`
 
+	// PathPrefix is an optional prefix for object storage.
+	PathPrefix string `json:"pathPrefix,omitempty"`
+
 	// This property is no longer used as of v0.1.1. See the standalone
 	// property that was pulled out of here instead. It's only left here
 	// to allow the migration to take place without data loss.

--- a/web/components/admin/config/server/EditStorage.tsx
+++ b/web/components/admin/config/server/EditStorage.tsx
@@ -28,7 +28,8 @@ const { Panel } = Collapse;
 // we could probably add more detailed checks here
 // `currentValues` is what's currently in the global store and in the db
 function checkSaveable(formValues: any, currentValues: any) {
-  const { endpoint, accessKey, secret, bucket, region, enabled, acl, forcePathStyle } = formValues;
+  const { endpoint, accessKey, secret, bucket, region, enabled, acl, forcePathStyle, pathPrefix } =
+    formValues;
   // if fields are filled out and different from what's in store, then return true
   if (enabled) {
     if (!!endpoint && isValidUrl(endpoint) && !!accessKey && !!secret && !!bucket && !!region) {
@@ -39,6 +40,7 @@ function checkSaveable(formValues: any, currentValues: any) {
         secret !== currentValues.secret ||
         bucket !== currentValues.bucket ||
         region !== currentValues.region ||
+        pathPrefix !== currentValues.pathPrefix ||
         (!currentValues.acl && acl !== '') ||
         (!!currentValues.acl && acl !== currentValues.acl) ||
         forcePathStyle !== currentValues.forcePathStyle
@@ -72,6 +74,7 @@ export default function EditStorage() {
     endpoint = '',
     region = '',
     secret = '',
+    pathPrefix = '',
     forcePathStyle = false,
   } = s3;
 
@@ -84,6 +87,7 @@ export default function EditStorage() {
       endpoint,
       region,
       secret,
+      pathPrefix,
       forcePathStyle,
     });
     setShouldDisplayForm(enabled);
@@ -215,6 +219,14 @@ export default function EditStorage() {
               <TextField
                 {...S3_TEXT_FIELDS_INFO.acl}
                 value={formDataValues.acl}
+                onChange={handleFieldChange}
+              />
+            </div>
+
+            <div className="field-container">
+              <TextField
+                {...S3_TEXT_FIELDS_INFO.pathPrefix}
+                value={formDataValues.pathPrefix}
                 onChange={handleFieldChange}
               />
             </div>

--- a/web/types/config-section.ts
+++ b/web/types/config-section.ts
@@ -81,6 +81,7 @@ export interface S3Field {
   endpoint: string;
   region: string;
   secret: string;
+  pathPrefix: string;
   forcePathStyle: boolean;
 }
 

--- a/web/utils/config-constants.tsx
+++ b/web/utils/config-constants.tsx
@@ -535,6 +535,13 @@ export const S3_TEXT_FIELDS_INFO = {
     placeholder: 'your secret key',
     tip: '',
   },
+  pathPrefix: {
+    fieldName: 'pathPrefix',
+    label: 'Path prefix',
+    maxLength: 255,
+    placeholder: '/my/custom/path',
+    tip: 'Optionally prepend a custom path for the final URL',
+  },
   forcePathStyle: {
     fieldName: 'forcePathStyle',
     label: 'Force path-style',

--- a/web/utils/server-status-context.tsx
+++ b/web/utils/server-status-context.tsx
@@ -39,6 +39,7 @@ const initialServerConfigState: ConfigDetails = {
     endpoint: '',
     region: '',
     secret: '',
+    pathPrefix: '',
     forcePathStyle: false,
   },
   yp: {


### PR DESCRIPTION
This adds support to object storage to set a custom storage path prefix via the admin.