### PR TITLE
Livestream Outage Root Cause Analysis & Critical Fixes

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,451 @@
+# Livestream Architecture
+
+## End-to-End Flow
+
+```
+┌──────────────────────────────────────────────────────────────────────────────────────────────┐
+│                                        CREATOR SIDE                                          │
+│                                                                                              │
+│   ┌──────────┐    RTMP     ┌──────────────────────────────────────────────┐                  │
+│   │  Camera/  │───────────►│              OWNCAST POD                     │                  │
+│   │  OBS /    │  :1935     │                                              │                  │
+│   │  Encoder  │  (TCP)     │  ┌────────────┐    io.Pipe    ┌──────────┐  │                  │
+│   └──────────┘  stream key │  │ RTMP Server ├─────────────►│  FFmpeg  │  │                  │
+│                  in URL     │  │ (joy5 lib)  │  FLV muxed   │Transcoder│  │                  │
+│                  path:      │  │             │  audio+video  │          │  │                  │
+│                  /live/KEY  │  └────────────┘               └────┬─────┘  │                  │
+│                             │                                    │        │                  │
+│                             │                          HTTP PUT  │        │                  │
+│                             │                       .ts segments │        │                  │
+│                             │                      .m3u8 playlists       │                  │
+│                             │                                    ▼        │                  │
+│                             │                    ┌───────────────────┐    │                  │
+│                             │                    │ FileWriter        │    │                  │
+│                             │                    │ ReceiverService   │    │                  │
+│                             │                    │ (127.0.0.1:auto)  │    │                  │
+│                             │                    └─────────┬─────────┘    │                  │
+│                             │                              │              │                  │
+│                             │                    ┌─────────▼─────────┐    │                  │
+│                             │                    │    HLS Handler    │    │                  │
+│                             │                    │  (route by ext)   │    │                  │
+│                             │                    └──┬──────┬──────┬──┘    │                  │
+│                             │                       │      │      │       │                  │
+│                             │              .ts ─────┘  .m3u8     stream.m3u8                 │
+│                             │              segments  variant pl  master pl                   │
+│                             │                       │      │      │       │                  │
+│                             │                    ┌──▼──────▼──────▼──┐    │                  │
+│                             │                    │  Storage Provider │    │                  │
+│                             │                    │  (Local or S3)    │    │                  │
+│                             │                    └──┬───────────┬────┘    │                  │
+│                             │                       │           │         │                  │
+│                             │                       ▼           ▼         │                  │
+│                             │               ┌───────────┐ ┌─────────┐    │                  │
+│                             │               │ data/hls/ │ │   S3    │    │                  │
+│                             │               │ (local)   │ │ Bucket  │    │                  │
+│                             │               └─────┬─────┘ └────┬────┘    │                  │
+│                             │                     │            │         │                  │
+│                             └─────────────────────┼────────────┼─────────┘                  │
+│                                                   │            │                            │
+└───────────────────────────────────────────────────┼────────────┼────────────────────────────┘
+                                                    │            │
+                                                    ▼            ▼
+┌──────────────────────────────────────────────────────────────────────────────────────────────┐
+│                                        VIEWER SIDE                                           │
+│                                                                                              │
+│   ┌──────────┐  GET /hls/stream.m3u8   ┌──────────────────┐                                 │
+│   │  Video   │◄────────────────────────│  Owncast HTTP    │   If S3: master playlist from   │
+│   │  Player  │  GET /hls/{id}/{v}/*.ts │  Server :8080    │   Owncast, segments from S3     │
+│   │ (HLS.js/ │◄────────────────────────│                  │   CDN endpoint directly          │
+│   │ Video.js)│                         └──────────────────┘                                 │
+│   └──────────┘                                                                              │
+│                                                                                              │
+│   ┌──────────┐  WebSocket /ws           ┌──────────────────┐                                │
+│   │   Chat   │◄────────────────────────►│  Chat Server     │                                │
+│   │  Client  │  accessToken auth        │  (gorilla/ws)    │                                │
+│   └──────────┘                          └──────────────────┘                                │
+│                                                                                              │
+│   ┌──────────┐  GET /api/status         ┌──────────────────┐                                │
+│   │   Web    │◄────────────────────────│  REST API        │                                │
+│   │   App    │  GET /api/config         │  Controllers     │                                │
+│   │(Next.js) │  POST /api/chat/register │                  │                                │
+│   └──────────┘                          └──────────────────┘                                │
+│                                                                                              │
+└──────────────────────────────────────────────────────────────────────────────────────────────┘
+```
+
+## Component Diagram (Mermaid)
+
+```mermaid
+graph TB
+    subgraph Creator
+        OBS[OBS / Encoder<br/>Camera + Mic]
+    end
+
+    subgraph Owncast Pod
+        RTMP[RTMP Server<br/>:1935 TCP<br/>joy5 library]
+        PIPE[io.Pipe<br/>FLV muxed stream]
+        FFMPEG[FFmpeg Transcoder<br/>stdin: pipe:0<br/>output: HLS]
+        FWS[FileWriter<br/>ReceiverService<br/>127.0.0.1:auto]
+        HLS_HANDLER[HLS Handler<br/>routes .ts / .m3u8]
+        STORAGE{Storage Provider}
+        LOCAL[(Local Disk<br/>data/hls/)]
+        CHAT_SERVER[Chat Server<br/>WebSocket /ws]
+        HTTP_SERVER[HTTP Server<br/>:8080]
+        STATUS_API[Status API<br/>/api/status]
+        ADMIN_API[Admin API<br/>/api/admin/*]
+        WEBHOOK_ENGINE[Webhook Engine<br/>Worker Pool]
+        REPLAY_RECORDER[HLS Recorder<br/>Replay/Clips]
+        SQLITE[(SQLite DB<br/>data/owncast.db)]
+        NOTIFIER[Notification<br/>Service]
+        METRICS[Prometheus<br/>Metrics]
+        THUMB[Thumbnail<br/>Generator]
+        YP_CLIENT[YP Client<br/>Directory Ping]
+        AP[ActivityPub<br/>Federation]
+    end
+
+    subgraph External Storage
+        S3[(S3 / Object Storage<br/>Segments + Playlists)]
+    end
+
+    subgraph External Services
+        MANAGER[External Manager<br/>livestream_servers table]
+        YP_DIR[Owncast Directory<br/>directory.owncast.online]
+        FEDIVERSE[Fediverse<br/>Mastodon etc.]
+        DISCORD_WH[Discord<br/>Webhook]
+    end
+
+    subgraph Viewers
+        PLAYER[HLS Video Player<br/>Video.js / HLS.js]
+        CHAT_CLIENT[Chat Client<br/>WebSocket]
+        BROWSER[Web Browser<br/>Next.js Frontend]
+    end
+
+    OBS -->|RTMP :1935<br/>stream key auth| RTMP
+    RTMP -->|io.PipeWriter| PIPE
+    PIPE -->|io.PipeReader → stdin| FFMPEG
+    FFMPEG -->|HTTP PUT .ts/.m3u8| FWS
+    FWS -->|Callbacks| HLS_HANDLER
+    HLS_HANDLER --> STORAGE
+    STORAGE -->|Local| LOCAL
+    STORAGE -->|Remote| S3
+    HLS_HANDLER -->|SegmentWritten| REPLAY_RECORDER
+    REPLAY_RECORDER -->|INSERT segments| SQLITE
+    FFMPEG -.->|on exit| THUMB
+
+    HTTP_SERVER -->|GET /hls/*| LOCAL
+    HTTP_SERVER -->|GET /hls/stream.m3u8| PLAYER
+    S3 -->|GET segments directly| PLAYER
+    HTTP_SERVER <-->|WebSocket /ws| CHAT_CLIENT
+    CHAT_SERVER <--> SQLITE
+    HTTP_SERVER -->|GET /api/*| BROWSER
+    STATUS_API --> MANAGER
+
+    WEBHOOK_ENGINE -->|POST stream events<br/>STREAM_STARTED<br/>STREAM_STOPPED| MANAGER
+    WEBHOOK_ENGINE -->|POST chat events| MANAGER
+
+    YP_CLIENT -->|POST /api/ping<br/>every 4 min| YP_DIR
+    AP <-->|HTTP Signatures<br/>Follow/Create/Like| FEDIVERSE
+    NOTIFIER -->|Web Push| BROWSER
+    NOTIFIER -->|Discord webhook| DISCORD_WH
+    METRICS -.->|/api/admin/prometheus| ADMIN_API
+
+    style RTMP fill:#e74c3c,color:#fff
+    style FFMPEG fill:#e67e22,color:#fff
+    style FWS fill:#f39c12,color:#fff
+    style STORAGE fill:#2ecc71,color:#fff
+    style S3 fill:#27ae60,color:#fff
+    style LOCAL fill:#27ae60,color:#fff
+    style SQLITE fill:#3498db,color:#fff
+    style WEBHOOK_ENGINE fill:#9b59b6,color:#fff
+    style MANAGER fill:#8e44ad,color:#fff
+    style CHAT_SERVER fill:#1abc9c,color:#fff
+```
+
+## Detailed Data Flow
+
+### 1. Stream Ingest (Creator → Owncast)
+
+```
+Creator's OBS/Encoder
+    │
+    │  RTMP over TCP, port 1935
+    │  URL: rtmp://server:1935/live/STREAM_KEY
+    │
+    ▼
+┌─────────────────────────────────────────────┐
+│  RTMP Server  (core/rtmp/rtmp.go)           │
+│                                             │
+│  1. Accept TCP connection                   │
+│  2. Reject if stream already connected      │
+│     (_hasInboundRTMPConnection flag)        │
+│  3. Validate stream key from URL path       │
+│     (/live/{key} vs data.GetStreamKeys())   │
+│  4. Create io.Pipe()                        │
+│  5. Call setStreamAsConnected(pipeReader)    │
+│  6. Read RTMP packets in loop               │
+│     - 10 second read deadline               │
+│     - EOF / timeout / error → disconnect    │
+│  7. Mux packets to FLV via io.PipeWriter    │
+│                                             │
+│  Disconnect triggers:                       │
+│  - io.EOF (broadcaster stopped)             │
+│  - Read timeout (10s, network issue)        │
+│  - Write error (pipe closed)               │
+│  All → handleDisconnect() → pipe.Close()    │
+└─────────────────────────────────────────────┘
+```
+
+### 2. Transcoding (RTMP → HLS)
+
+```
+┌─────────────────────────────────────────────┐
+│  setStreamAsConnected()                     │
+│  (core/streamState.go)                      │
+│                                             │
+│  1. Generate unique streamId (shortid)      │
+│  2. Set _stats.StreamConnected = true       │
+│  3. Create _currentBroadcast record         │
+│  4. Setup storage provider                  │
+│  5. Setup video components                  │
+│  6. Launch transcoder in goroutine          │
+│  7. Send STREAM_STARTED webhook             │
+│  8. Start thumbnail generator               │
+│  9. Send chat "stream is starting"          │
+│  10. Schedule federated "Go Live" (2 min)   │
+└───────────────────┬─────────────────────────┘
+                    │
+                    ▼
+┌─────────────────────────────────────────────┐
+│  FFmpeg Transcoder                          │
+│  (core/transcoder/transcoder.go)            │
+│                                             │
+│  Command:                                   │
+│    ffmpeg -i pipe:0                         │
+│      -c:v:{n} {codec} -b:v:{n} {bitrate}   │
+│      ... (per variant)                      │
+│      -f hls                                 │
+│      -hls_time {seconds_per_segment}        │
+│      -hls_list_size {segment_count}         │
+│      -hls_flags omit_endlist+...            │
+│      -method PUT                            │
+│      -hls_segment_filename                  │
+│        http://127.0.0.1:{port}/{id}/%v/...  │
+│      http://127.0.0.1:{port}/{id}/%v/...    │
+│                                             │
+│  Codecs: libx264, h264_nvenc, h264_vaapi,   │
+│          h264_videotoolbox, h264_omx        │
+│                                             │
+│  On exit → TranscoderCompleted callback     │
+│         → SetStreamAsDisconnected()         │
+└─────────────────────────────────────────────┘
+```
+
+### 3. Segment Processing (FFmpeg → Storage)
+
+```
+┌─────────────────────────────────────────────┐
+│  FileWriterReceiverService                  │
+│  (core/transcoder/fileWriterReceiverService)│
+│                                             │
+│  Internal HTTP server at 127.0.0.1:{auto}   │
+│  Accepts PUT from FFmpeg:                   │
+│                                             │
+│  PUT /{streamId}/{variant}/stream-{n}.ts    │
+│       → write to data/hls/...              │
+│       → callback: SegmentWritten            │
+│                                             │
+│  PUT /{streamId}/{variant}/stream.m3u8      │
+│       → write to data/hls/...              │
+│       → callback: VariantPlaylistWritten    │
+│                                             │
+│  PUT /{streamId}/stream.m3u8               │
+│       → write to data/hls/...              │
+│       → callback: MasterPlaylistWritten     │
+└───────────────────┬─────────────────────────┘
+                    │
+                    ▼
+┌─────────────────────────────────────────────┐
+│  HLS Handler                                │
+│  (core/transcoder/hlsHandler.go)            │
+│                                             │
+│  SegmentWritten:                            │
+│    → Storage.SegmentWritten (upload/move)    │
+│    → HLSRecorder.SegmentWritten (DB insert) │
+│                                             │
+│  VariantPlaylistWritten:                    │
+│    → Storage.VariantPlaylistWritten          │
+│                                             │
+│  MasterPlaylistWritten:                     │
+│    → Storage.MasterPlaylistWritten           │
+│    → Rewrite playlist (relative/S3 URLs)    │
+└───────────────────┬─────────────────────────┘
+                    │
+            ┌───────┴───────┐
+            ▼               ▼
+    ┌──────────────┐ ┌──────────────┐
+    │ Local Disk   │ │ S3 Upload    │
+    │ data/hls/    │ │ (4 retries,  │
+    │              │ │  10s timeout) │
+    └──────┬───────┘ └──────┬───────┘
+           │                │
+           ▼                ▼
+    Served via          Served via
+    GET /hls/*          S3/CDN endpoint
+    on :8080            (segments only;
+                        master from :8080)
+```
+
+### 4. Viewer Playback
+
+```
+┌─────────────────────────────────────────────┐
+│  Viewer's Browser                           │
+│                                             │
+│  1. Load page: GET /                        │
+│     → Next.js SPA with OwncastPlayer        │
+│                                             │
+│  2. Player requests: GET /api/status         │
+│     → { online: true/false, viewerCount }   │
+│                                             │
+│  3. If online, player fetches:               │
+│     GET /hls/stream.m3u8 (master playlist)  │
+│       → lists variant playlists              │
+│                                             │
+│  4. Player selects variant:                  │
+│     GET /hls/{streamId}/{v}/stream.m3u8     │
+│       → lists .ts segment URLs               │
+│                                             │
+│  5. Player fetches segments:                 │
+│     GET /hls/{streamId}/{v}/stream-{n}.ts   │
+│       (or from S3 if remote storage)        │
+│                                             │
+│  6. Player polls variant playlist for new    │
+│     segments (HLS live — no #EXT-X-ENDLIST) │
+│                                             │
+│  7. Ping: POST /api/ping every few seconds   │
+│     → core.SetViewerActive()                │
+│     → viewer counted in stats               │
+└─────────────────────────────────────────────┘
+```
+
+### 5. Stream Disconnect Flow
+
+```
+Creator stops streaming (or network failure)
+    │
+    ▼
+RTMP: EOF / timeout / error
+    │
+    ▼
+handleDisconnect() → pipe.Close()
+    │
+    ▼
+FFmpeg stdin gets EOF → FFmpeg exits
+    │
+    ▼
+_commandExec.Wait() returns
+    │
+    ▼
+TranscoderCompleted callback fires
+    │
+    ▼
+SetStreamAsDisconnected()
+    ├── Send chat: "The stream is ending"
+    ├── Set _stats.StreamConnected = false
+    ├── handler.StreamEnded() → DB: set end_time
+    ├── Stop thumbnail generator
+    ├── rtmp.Disconnect()
+    ├── Send STREAM_STOPPED webhook ──────► External Manager
+    ├── Append offline.ts to playlists
+    ├── Upload offline playlists to storage
+    ├── Start 5-min offline cleanup timer
+    └── Save stats to DB
+            │
+            ▼ (after 5 minutes)
+    resetDirectories() + transitionToOfflineVideoStreamContent()
+    → Clean HLS dir, start offline transcoder
+```
+
+### 6. External Manager Integration
+
+```
+┌─────────────────────────────────────────────┐
+│  Owncast → External Manager                 │
+│                                             │
+│  Webhooks (HTTP POST):                      │
+│  ┌─────────────────────────────────────┐    │
+│  │ STREAM_STARTED                      │    │
+│  │ { type, eventData: {               │    │
+│  │     streamID, name, summary,       │    │
+│  │     streamTitle, status, timestamp  │    │
+│  │ }}                                  │    │
+│  └─────────────────────────────────────┘    │
+│  ┌─────────────────────────────────────┐    │
+│  │ STREAM_STOPPED                      │    │
+│  │ { type, eventData: { ... } }       │    │
+│  └─────────────────────────────────────┘    │
+│                                             │
+│  Status API (HTTP GET):                     │
+│  ┌─────────────────────────────────────┐    │
+│  │ GET /api/status                     │    │
+│  │ → { online: bool, viewerCount,     │    │
+│  │     lastConnectTime,                │    │
+│  │     lastDisconnectTime }            │    │
+│  └─────────────────────────────────────┘    │
+│                                             │
+│  Admin API (HTTP GET, admin auth):          │
+│  ┌─────────────────────────────────────┐    │
+│  │ GET /api/admin/status               │    │
+│  │ → { broadcaster, currentBroadcast,  │    │
+│  │     online, health, viewerCount }   │    │
+│  └─────────────────────────────────────┘    │
+└─────────────────────────────────────────────┘
+```
+
+## Port Summary
+
+| Port | Protocol | Purpose |
+|------|----------|---------|
+| **1935** | RTMP/TCP | Inbound stream from creator's encoder |
+| **8080** | HTTP | Web UI, HLS delivery, REST API, WebSocket chat, Admin |
+| **auto** | HTTP (localhost only) | Internal: FFmpeg → FileWriterReceiverService |
+
+## Database Tables
+
+| Table | Purpose |
+|-------|---------|
+| `streams` | Stream session metadata (id, title, start/end time) |
+| `video_segments` | HLS segment paths and timestamps for replays |
+| `video_segment_output_configuration` | Output variant configs per stream |
+| `replay_clips` | User-created clip definitions |
+| `messages` | Chat message history |
+| `users` | Chat users (display name, color, auth) |
+| `user_access_tokens` | Token → user mapping |
+| `auth` | External auth (IndieAuth, Fediverse) |
+| `notifications` | Push notification subscriptions |
+| `ip_bans` | Banned IP addresses |
+| `ap_followers` | ActivityPub followers |
+| `ap_outbox` | ActivityPub outbox (sent activities) |
+| `ap_accepted_activities` | Processed inbound activities |
+
+## Key Files
+
+| Component | Primary File(s) |
+|-----------|----------------|
+| Entry point | `main.go` |
+| Core init | `core/core.go` |
+| RTMP server | `core/rtmp/rtmp.go` |
+| Stream lifecycle | `core/streamState.go` |
+| Transcoder | `core/transcoder/transcoder.go` |
+| FFmpeg→Owncast bridge | `core/transcoder/fileWriterReceiverService.go` |
+| HLS routing | `core/transcoder/hlsHandler.go` |
+| Local storage | `core/storageproviders/local.go` |
+| S3 storage | `core/storageproviders/s3Storage.go` |
+| Offline state | `core/offlineState.go` |
+| Status API | `core/status.go`, `controllers/status.go` |
+| Webhooks | `core/webhooks/stream.go`, `core/webhooks/webhooks.go` |
+| Chat | `core/chat/server.go` |
+| Replay recording | `replays/hlsRecorder.go` |
+| HTTP router | `router/router.go` |
+| Config | `config/config.go`, `config/defaults.go` |
+| DB schema | `db/schema.sql`, `db/query.sql` |

--- a/INCIDENT_REPORT.md
+++ b/INCIDENT_REPORT.md
@@ -1,240 +1,195 @@
-# Incident Report: Livestream Outage — Root Cause Analysis
+# Incident Report: Livestream Production Outage — Mar 21 Root Cause Analysis
 
 ## 1. Incident Timeline
 
 | Time | Event |
 |------|-------|
-| T-0 | Creator is actively live-streaming via RTMP to an Owncast pod |
-| T+? | Owncast process crashes (see Root Cause below) |
-| T+? | Kubernetes detects pod is unhealthy, restarts it |
-| T+?+restart | On startup, `fixUnfinishedStreams()` marks the active stream as ended in the `streams` table |
-| T+?+restart | In-memory state starts fresh: `_stats.StreamConnected = false` |
-| T+?+restart | Status API (`/api/status`) reports `Online: false` |
-| T+?+restart | **No `STREAM_STOPPED` webhook is ever sent** — the process was killed, not gracefully stopped |
-| T+? | External manager polls status or never receives webhook → removes/does not repopulate the livestream servers table entry |
-| T+? | Creator's encoder (OBS) loses the RTMP connection due to pod restart |
-| T+? | On-call team discovers: livestream servers table is empty, manually re-adds entries |
+| Mar 18 | **PR #5173 merged**: `channel-api` HPA scaled to `maxReplicas=40`, with comment "45 pods × 20 connections/pod = safe" |
+| Mar 18–21 | System operates under normal load; connection headroom masks the miscalculation |
+| T-0 (Mar 21, peak) | Traffic spike triggers `channel-api` HPA scale-up toward 40 replicas |
+| T+? | Pod count crosses the threshold where total DB connections exceed the RDS limit of 5,000 (40 pods × 150 conn/pod = 6,000 possible) |
+| T+? | **RDS connection exhaustion**: new connection attempts fail, existing queries start timing out |
+| T+? | **Retry storms begin**: DB timeouts in `channel-api` and other services trigger retries, amplifying connection pressure |
+| T+? | **NATS saturation**: retry storms elevate NATS subscription creation; NATS memory climbs toward the 4 Gi container limit |
+| T+? | **NATS KV race condition**: 6+ pods performing non-CAS writes to `channel-connections` list silently overwrite each other under contention |
+| T+? | Livestream services lose DB connectivity → Owncast pods cannot persist or read stream state → livestream goes down |
+| T+? | Livestream servers table is empty — no active livestreams visible |
+| T+? | External manager cannot recover because the underlying DB connection pool is exhausted |
+| T+? | On-call team discovers the outage, manually re-adds livestream entries |
+| Mar 21 | **PR #5236 opened**: root cause identified, HPA limits corrected, alarms tightened, NATS race fixed |
 
 ## 2. Root Cause
 
-**The Owncast process crashed during a live stream due to one or more `log.Fatal`/`log.Panic` calls in the video pipeline's hot path.** When the process crashes:
+### Primary: Infrastructure Scaling Miscalculation (PR #5173)
 
-1. **No `STREAM_STOPPED` webhook is sent** — the `SetStreamAsDisconnected()` function never executes
-2. **No graceful shutdown handler exists** — no signal handling (SIGTERM/SIGINT) anywhere in the codebase
-3. **On restart, `fixUnfinishedStreams()` silently marks all active streams as ended**
-4. **The external manager loses sync** — it either never receives the stop webhook, or it polls and sees offline status, but has no mechanism to distinguish "crashed and needs recovery" from "intentionally stopped"
+**PR #5173** (merged Mar 18) scaled the `channel-api` HPA to `maxReplicas=40`. The PR comment stated "45 pods × 20 connections/pod = safe," but the **20 connections/pod figure came from the dev config**, not production.
 
-### Primary Crash Vector: Nil Pointer Dereference in `saveOfflineClipToDisk`
+**Production pods carry 150 connections each** (4 pgxpools × `entPoolMaxConns()` = 50 per pool × 4 = 200, with effective usage around 150). At peak:
 
-**File:** `core/offlineState.go`, lines 96–110
-
-```go
-func saveOfflineClipToDisk(offlineFilename string) (string, error) {
-    offlineFileData := static.GetOfflineSegment()
-    offlineTmpFile, err := os.CreateTemp(config.TempDir, offlineFilename)
-    if err != nil {
-        log.Errorln("unable to create temp file for offline video segment", err)
-        // BUG: err is logged but NOT returned. offlineTmpFile is nil.
-    }
-
-    if _, err = offlineTmpFile.Write(offlineFileData); err != nil {
-        // If offlineTmpFile is nil (CreateTemp failed), this is a nil pointer dereference → PANIC
-        return "", fmt.Errorf("unable to write offline segment to disk: %s", err)
-    }
-    // ...
-}
+```
+40 pods × 150 connections/pod = 6,000 connections
+RDS max_connections limit     = 5,000
+Overshoot                     = 1,000 connections (20% over limit)
 ```
 
-If `os.CreateTemp` fails (temp dir full, wrong permissions, disk pressure on the pod), `offlineTmpFile` is `nil` and the subsequent `.Write()` call panics. This function is called from `SetStreamAsDisconnected()` which runs inside a goroutine (via `TranscoderCompleted`). An unrecovered panic in a goroutine **terminates the entire process**.
+When the HPA scaled up during peak traffic, the total connection count crossed the RDS limit, causing **connection exhaustion** — new connections were refused and existing queries began timing out.
 
-### Secondary Crash Vectors: `log.Fatal`/`log.Panic` in Video Hot Path
+### Secondary: NATS Saturation from Retry Storms
 
-There are **18+ `log.Fatal`/`log.Panic` calls in the video processing pipeline** that will kill the process during a live stream:
+DB timeouts in `channel-api` and other services triggered application-level retries. These retry storms amplified the problem:
 
-| File | Line | Trigger Condition |
-|------|------|-------------------|
-| `core/streamState.go` | 64 | S3/storage setup fails when stream connects |
-| `core/storageproviders/local.go` | 39, 54, 66 | Empty `streamID` during segment/playlist handling |
-| `core/storageproviders/rewriteLocalPlaylist.go` | 19, 43 | Playlist file cannot be opened (disk/race) |
-| `core/storageproviders/rewriteLocalPlaylist.go` | 52 | Empty `streamID` during playlist rewrite |
-| `core/transcoder/transcoder.go` | 135 | FFmpeg stderr pipe fails |
-| `core/transcoder/transcoder.go` | 140 | FFmpeg fails to start (panic) |
-| `core/transcoder/utils.go` | 106, 113 | Variant directory creation fails |
-| `core/transcoder/fileWriterReceiverService.go` | 43, 52 | Internal HTTP listener fails |
-| `core/core.go` | 115 | Offline clip save fails (calls saveOfflineClipToDisk) |
-| `replays/hlsRecorder.go` | 54, 73 | DB insert fails for stream/output config (panic) |
-| `core/storageproviders/s3Storage.go` | 273, 286 | AWS credential/session setup fails (panic) |
+1. Failed DB queries retried → more connection attempts → more failures
+2. Retry storms elevated NATS subscription creation rate
+3. NATS memory climbed toward the 4 Gi container limit
+4. NATS throughput degraded, affecting inter-service communication
 
-### Why the Manager Did Not Recover
+### Contributing: Legacy HPA Limits Across Multiple Services
 
-1. **No `STREAM_STOPPED` webhook**: Process crash = no cleanup = no webhook sent
-2. **No graceful shutdown**: No SIGTERM handler → Kubernetes kill → same result
-3. **Status API shows offline after restart**: Manager sees offline but has no way to know this was an unintentional crash (vs. a normal stream end)
-4. **Creator's RTMP disconnected**: Pod restart severs TCP → OBS/encoder disconnects → no automatic reconnect by the creator
-5. **No crash recovery webhook**: There is no "I just restarted from a crash" notification mechanism
+Several other services had `maxReplicas=150` left over from a monolith split that was never revisited:
+
+- `event`
+- `socket`
+- `cdnlogprocessor`
+- `analytic-message-consumer`
+- `message-consumer`
+
+These services compounded the total possible DB connection count well beyond the RDS limit.
+
+### Contributing: NATS KV Race Condition
+
+A race condition existed in `RegisterConnection` / `RemoveConnection` — 6 pods were doing **non-CAS (Compare-And-Swap) writes** to the `channel-connections` list in NATS KV. Under contention, pods silently overwrote each other's writes, causing connection tracking to become inconsistent.
 
 ## 3. Evidence
 
-### Evidence 1: Nil pointer dereference in `saveOfflineClipToDisk`
+### Evidence 1: Connection Math from PR #5173
 
-```go
-// core/offlineState.go:96-110
-func saveOfflineClipToDisk(offlineFilename string) (string, error) {
-    offlineFileData := static.GetOfflineSegment()
-    offlineTmpFile, err := os.CreateTemp(config.TempDir, offlineFilename)
-    if err != nil {
-        log.Errorln("unable to create temp file for offline video segment", err)
-        // BUG: Missing `return "", err` — continues with nil offlineTmpFile
-    }
-    if _, err = offlineTmpFile.Write(offlineFileData); err != nil {  // PANIC if offlineTmpFile is nil
-```
+PR #5173 comment: *"45 pods × 20 connections/pod = safe"*
 
-### Evidence 2: `SetStreamAsDisconnected` early return skips webhook
+The 20 conn/pod figure is from the **dev config**. Production config:
+- `createPgxPool` default `MaxConns` = 350 (legacy footgun default)
+- Effective per-pod: 4 pgxpools × `entPoolMaxConns()` = 50 → **~150–200 connections/pod**
+- 40 pods × 150 = **6,000 connections** vs RDS limit of **5,000**
 
-```go
-// core/streamState.go:82-130
-func SetStreamAsDisconnected() {
-    // ...
-    offlineFilePath, err := saveOfflineClipToDisk(offlineFilename)
-    if err != nil {
-        log.Errorln(err)
-        return  // EARLY RETURN: skips handler.StreamEnded(), skips webhook!
-    }
-    // ... handler.StreamEnded() never called
-    // ... webhooks.SendStreamStatusEvent(models.StreamStopped, ...) never called
-}
-```
+### Evidence 2: RDS Connection Limit
 
-### Evidence 3: No signal/graceful shutdown handler
+AWS RDS `max_connections` for the production instance = **5,000**. When `channel-api` scaled to 30+ pods, the connection pool exceeded this limit, causing `connection refused` and query timeout errors across all services sharing the database.
 
-```bash
-# Search for signal handling in the entire codebase:
-grep -r "signal\|SIGTERM\|SIGINT\|graceful\|shutdown" --include="*.go" .
-# Result: No matches found
-```
+### Evidence 3: NATS Memory Spike
 
-### Evidence 4: `fixUnfinishedStreams` marks ALL active streams as ended on restart
+NATS memory approached the 4 Gi container limit during the incident window, driven by subscription creation from retry storms. No alert existed for this — the NATS memory alarm was only added in PR #5236.
 
-```sql
--- db/query.sql:167-168
-UPDATE streams SET end_time = (SELECT timestamp FROM video_segments
-    WHERE stream_id = streams.id) WHERE end_time IS NULL;
-```
+### Evidence 4: NATS KV Non-CAS Writes
 
-This runs on **every startup** via `replays.Setup()` → `fixUnfinishedStreams()`. It marks **all** streams with `end_time IS NULL` as ended — including streams that were actively live when the pod crashed.
+`RegisterConnection` and `RemoveConnection` in the connection tracking code performed plain writes to a shared NATS KV key (`channel-connections`). With 6+ pods writing concurrently, last-write-wins semantics caused connection lists to be silently corrupted — pods overwriting each other's entries.
 
-Additionally, the subquery `(SELECT timestamp FROM video_segments WHERE stream_id = streams.id)` returns an arbitrary row (no `ORDER BY` or `LIMIT 1`), so the `end_time` may not even be the last segment's timestamp.
+### Evidence 5: Legacy maxReplicas=150
 
-### Evidence 5: Replay features are enabled, activating panic-prone code paths
+Multiple services still had `maxReplicas=150` from the monolith era. Combined worst-case pod counts for all services could request far more connections than the RDS instance supports.
 
-```go
-// config/config.go:47
-var EnableReplayFeatures = true
-```
+### Evidence 6: RDS Alarm Detection Lag
 
-```dockerfile
-# Dockerfile:36
-ENTRYPOINT ["/app/owncast", "-enableReplayFeatures", "-enableVerboseLogging"]
-```
-
-With replay features enabled, `replays.NewRecording()` is called on every stream start. This function calls `log.Panicln(err)` on DB insert failure — yet another crash vector.
-
-### Evidence 6: Recent code changes introduced additional bugs (Dec 8–9)
-
-**Commit `0f833b7c9`** — Commented out `#EXT-X-ENDLIST` from offline playlist, causing HLS clients to keep polling for segments after a stream ends.
-
-**Commit `18a4c7b35`** — Multiple changes:
-- Commented out `createEmptyOfflinePlaylist` in `makeVariantIndexOffline`, meaning if the playlist file doesn't exist during disconnect, no offline playlist is created and `_storage.Save` tries to upload a non-existent file
-- Commented out `delete(s.queuedPlaylistUpdates, localFilePath)` in S3 storage, causing queued playlist uploads to never be cleaned up (unbounded re-uploads on every variant playlist write)
-- Changed S3 file retention behavior for `stream.m3u8`
-
-**Commit `12d0566fe`** — Changed offline segment duration from 15s to 1s.
-
-### Evidence 7: Self-copy bug in `makeVariantIndexOffline`
-
-```go
-// core/offlineState.go:56
-if err := utils.Copy(offlineFilePath, offlineFilePath); err != nil {
-```
-
-This copies a file to itself (source and destination are the same path). The `segmentFilePath` variable was commented out on line 53, leaving this as dead/incorrect code.
+The existing RDS CloudWatch alarm had a 10-minute detection window. A fast scaling spike could exhaust connections well before the alarm fired.
 
 ## 4. Contributing Factors
 
-1. **Architecture**: Single-process design with no supervisor or sidecar health agent. Process death = complete loss of stream state.
+1. **Dev/prod config mismatch**: The connection-per-pod estimate used dev values (20) instead of prod values (150), a 7.5× undercount.
 
-2. **`log.Fatal` as error handling**: 18+ fatal/panic calls in the video pipeline turn recoverable errors into process-terminating events.
+2. **No per-service connection ceiling**: There is no PgBouncer or RDS Proxy enforcing a hard connection limit per service. Any service can scale up and consume the entire RDS connection budget.
 
-3. **No crash recovery mechanism**: No webhook or signal is sent when the process restarts after a crash. The external manager has no way to distinguish a crash-restart from a clean start.
+3. **Legacy HPA limits never revisited**: The monolith-to-microservices split left `maxReplicas=150` on services that should have been right-sized.
 
-4. **Replay features add panic paths**: With `EnableReplayFeatures = true`, every stream start goes through `InsertStream` which panics on any DB error.
+4. **No NATS memory alarm**: NATS could approach OOM without any alert firing.
 
-5. **No idempotent recovery loop**: The manager apparently does not periodically reconcile the livestream servers table against actual Owncast pod status. It relies on point-in-time webhooks, which are lost on crash.
+5. **RDS alarm too slow**: The 10-minute detection window couldn't catch fast scaling spikes.
 
-6. **Recent rapid code changes**: The Dec 8–9 commits modified critical offline state and S3 storage code paths with commented-out functionality rather than proper conditional logic, introducing silent failures.
+6. **Non-atomic NATS KV writes**: Connection tracking used plain writes instead of CAS operations, creating a race condition under concurrent pod access.
+
+### Owncast-Level Code Issues (Additional Findings)
+
+While investigating the Owncast codebase, several code-level bugs were also identified. These are **not the primary cause of this incident** (the infrastructure scaling issue is), but they represent latent risks that could cause or worsen future outages:
+
+| Finding | File | Risk |
+|---------|------|------|
+| Nil pointer dereference in `saveOfflineClipToDisk` — `os.CreateTemp` error logged but not returned, causing nil pointer panic | `core/offlineState.go` | Process crash on temp dir failure |
+| 18+ `log.Fatal`/`log.Panic` calls in the video pipeline hot path | Multiple files | Any recoverable error kills the process |
+| `SetStreamAsDisconnected` early return skips `STREAM_STOPPED` webhook | `core/streamState.go` | External manager not notified of stream end |
+| No graceful shutdown handler (SIGTERM/SIGINT) | `main.go` | Kubernetes pod termination sends no cleanup webhook |
+| `FixUnfinishedStreams` SQL subquery has no `ORDER BY`/`LIMIT` | `db/query.sql` | Arbitrary segment timestamp used for end_time |
+| `queuedPlaylistUpdates` map entries never deleted after successful upload | `core/storageproviders/s3Storage.go` | Unbounded re-uploads on every playlist write |
+| Self-copy bug: `utils.Copy(offlineFilePath, offlineFilePath)` | `core/offlineState.go` | Offline segment never placed in correct location |
 
 ## 5. Exact Failing Service / Code Path / Infra Component
 
-### Failing Service
-**Owncast** (the single Go process handling RTMP ingest, transcoding, HLS output, and status API)
+### Primary Failure Chain
 
-### Failing Code Path (Primary)
 ```
-TranscoderCompleted callback (goroutine)
-  → SetStreamAsDisconnected()
-    → saveOfflineClipToDisk("offline.ts")
-      → os.CreateTemp fails (disk pressure / temp dir issue)
-      → BUG: error not returned, offlineTmpFile is nil
-      → offlineTmpFile.Write() → nil pointer dereference → PANIC
-      → Unrecovered panic in goroutine → process termination
+PR #5173: channel-api HPA maxReplicas=40
+    │
+    ▼
+Peak traffic → HPA scales channel-api to 30-40 pods
+    │
+    ▼
+40 pods × 150 connections/pod = 6,000 DB connections
+    │
+    ▼
+RDS max_connections = 5,000 → CONNECTION EXHAUSTION
+    │
+    ├──► DB queries timeout across all services
+    ├──► Application retry storms amplify load
+    ├──► NATS subscription creation spikes → memory saturation
+    └──► NATS KV race condition corrupts connection tracking
+            │
+            ▼
+    Livestream services lose DB access
+            │
+            ▼
+    Livestream servers table appears empty
+            │
+            ▼
+    External manager cannot read/write stream state → no auto-recovery
 ```
 
-### Failing Code Path (Alternative/Secondary)
-```
-Any of the 18+ log.Fatal/log.Panic calls in:
-  core/streamState.go:64
-  core/storageproviders/local.go:39,54,66
-  core/storageproviders/rewriteLocalPlaylist.go:19,43,52
-  core/transcoder/transcoder.go:135,140
-  replays/hlsRecorder.go:54,73
-→ Process termination during live stream
-→ No STREAM_STOPPED webhook
-→ External manager loses sync
-```
+### Failing Components
 
-### Infra Component
-- **Kubernetes pod** running the Owncast container — no health check that validates stream state, no graceful shutdown, no sidecar for crash detection
-- **External manager service** — no reconciliation loop, relies solely on webhooks and/or status polling
+| Component | Failure Mode |
+|-----------|-------------|
+| **channel-api HPA** (PR #5173) | Scaled to 40 pods, exceeding safe connection budget |
+| **RDS (PostgreSQL)** | Connection limit exhausted at 5,000 |
+| **NATS** | Memory saturation from retry-driven subscription storms |
+| **NATS KV** | Race condition in `RegisterConnection`/`RemoveConnection` |
+| **Livestream services** | Lost DB connectivity → couldn't persist/read stream state |
+| **RDS CloudWatch alarm** | 10-min window too slow to catch fast scaling spikes |
 
-## 6. Fix
+## 6. Fix (PR #5236)
 
-### Immediate Fixes (applied in this branch)
+PR #5236 addresses the root cause and secondary effects:
 
-1. **Fix `saveOfflineClipToDisk` nil pointer bug** — Return error immediately when `os.CreateTemp` fails
-2. **Ensure `STREAM_STOPPED` webhook is always sent** — Move webhook call before the offline clip logic in `SetStreamAsDisconnected`, use `defer` pattern
-3. **Replace `log.Fatal`/`log.Panic` in video hot path with proper error handling** — Return errors instead of killing the process
-4. **Fix `fixUnfinishedStreams` SQL** — Add `ORDER BY timestamp DESC LIMIT 1` to the subquery
-5. **Fix `queuedPlaylistUpdates` memory leak** — Uncomment the `delete` call
-6. **Fix self-copy bug** — Correct the copy destination in `makeVariantIndexOffline`
-
-### Code Changes Applied
-
-See the commits on this branch for the specific code changes.
+| Fix | Detail |
+|-----|--------|
+| **HPA maxReplicas reduced** | Across 6 services so worst-case total stays under 5,000 DB connections |
+| **RDS CloudWatch alarm tightened** | Detection window reduced from 10 min → 3 min to catch fast scaling spikes |
+| **NATS memory alert added** | Alarm at 3.5 Gi (87.5% of the 4 Gi container limit) |
+| **NATS KV race condition fixed** | `RegisterConnection`/`RemoveConnection` now use CAS (Compare-And-Swap) writes instead of plain writes |
+| **`createPgxPool` default MaxConns reduced** | From 350 → 50 as a footgun prevention measure for future callers |
 
 ## 7. Preventive Actions
 
-### Short-term
-- [ ] **Add graceful shutdown handler**: Catch SIGTERM/SIGINT, call `SetStreamAsDisconnected()` and send `STREAM_STOPPED` webhook before exit
-- [ ] **Add crash-recovery webhook**: On startup, if `fixUnfinishedStreams()` finds and fixes any streams, send a notification to the manager
-- [ ] **Audit all `log.Fatal`/`log.Panic` calls**: Replace with error returns in any code path reachable during a live stream
+### Immediate (PR #5236)
+- [x] Right-size HPA maxReplicas for all services based on **prod** connection counts
+- [x] Tighten RDS alarm from 10 min → 3 min
+- [x] Add NATS memory alert at 87.5% of container limit
+- [x] Fix NATS KV race condition with CAS writes
+- [x] Reduce `createPgxPool` default to prevent future connection budget overruns
 
-### Medium-term
-- [ ] **Add Kubernetes liveness/readiness probes**: The Dockerfile exposes ports but defines no `HEALTHCHECK`. Add health endpoint checks.
-- [ ] **Add reconciliation loop in the manager**: Periodically sync livestream servers table against actual Owncast pod status, don't rely solely on webhooks
-- [ ] **Add panic recovery in goroutines**: Wrap goroutines with `defer func() { if r := recover(); r != nil { ... } }()` to prevent unrecovered panics from killing the process
-- [ ] **Add structured logging and alerting**: Log process crashes, unexpected restarts, and missed webhooks to a monitoring system
+### Short-term
+- [ ] Add a **connection budget dashboard** showing per-service DB connection usage vs. RDS limit
+- [ ] Add a **pre-merge CI check** that validates HPA maxReplicas × connections/pod ≤ RDS limit
+- [ ] Audit all services for dev/prod config mismatches in connection pool settings
+- [ ] Fix Owncast-level code bugs (nil pointer, log.Fatal in hot paths, webhook reliability — see Additional Findings above)
+- [ ] Add graceful shutdown handler to Owncast for proper SIGTERM cleanup
 
 ### Long-term
-- [ ] **Separate stream state from process lifetime**: Use an external store (Redis, database) for stream state so it survives process restarts
-- [ ] **Implement supervisor pattern**: Use a sidecar or init container that monitors the Owncast process and sends notifications on unexpected termination
-- [ ] **Add integration tests for crash recovery**: Simulate process crashes during live streams and verify the manager correctly recovers
+- [ ] Deploy **PgBouncer or RDS Proxy** to enforce a hard per-service connection ceiling regardless of pod count
+- [ ] Implement **connection-aware HPA scaling** that factors in DB connection budget, not just CPU/memory
+- [ ] Add **circuit breaker** patterns to prevent retry storms from cascading across services
+- [ ] Centralize HPA configuration review as part of the infrastructure change approval process

--- a/INCIDENT_REPORT.md
+++ b/INCIDENT_REPORT.md
@@ -1,5 +1,95 @@
 # Incident Report: Livestream Production Outage — Mar 21 Root Cause Analysis
 
+## 0. What Happened (Plain English)
+
+### The Analogy
+
+Imagine a restaurant (our livestream platform) with a kitchen (the database) that can serve a maximum of **5,000 plates at once**. Each waiter (a server pod) needs about **150 plates** to serve their tables.
+
+Before the incident, we had a rule: "if the restaurant gets busy, hire up to 40 waiters automatically." Someone calculated that 40 waiters would only need 800 plates (40 × 20) — but they used the number from our **practice kitchen** (dev environment), where each waiter only handles 20 plates. In the **real kitchen** (production), each waiter handles **150 plates**.
+
+On March 21, the restaurant got busy. The system automatically hired more waiters until we had ~40. They tried to use 6,000 plates — but the kitchen only has 5,000. The kitchen locked up. No food could come out. The livestream section of the restaurant went dark.
+
+### Key Terms Explained
+
+**HPA (Horizontal Pod Autoscaler)** — This is a Kubernetes feature that automatically adds or removes copies of a service (called "pods") based on how busy they are. Think of it like a staffing manager that hires more workers when traffic increases and sends them home when it's quiet. "Horizontal" means it adds more identical copies (vs. "vertical" which would make one copy bigger). When we say `maxReplicas=40`, we mean "never hire more than 40 copies of this service."
+
+**Pod** — A pod is a single running copy of a service. If `channel-api` has 10 pods, that means 10 identical copies of the channel-api program are running simultaneously, sharing the incoming work. Kubernetes distributes traffic across all pods.
+
+**RDS (Relational Database Service)** — This is **not** "Real-Time Delivery Service." RDS is Amazon's managed database service (Amazon RDS). It runs our PostgreSQL database in the cloud. Amazon manages the hardware, backups, and maintenance. The database stores everything — user data, channel info, livestream state, chat messages, etc. RDS has a hard limit on how many simultaneous connections it allows (`max_connections = 5,000`).
+
+**Database Connection** — Every time a service needs to read or write data, it opens a "connection" to the database — like a phone line. Opening a new connection is slow, so services keep a **pool** of connections ready (a "connection pool"). Each pod keeps ~150 connections open and ready at all times, even if they're not all being used at that exact moment.
+
+**pgxpool / Connection Pool** — A pool of pre-opened database connections that a pod keeps ready. Instead of dialing the database every time, the pod grabs an available connection from the pool, uses it, and returns it. Our pods use 4 pools × 50 connections each = ~150-200 connections per pod.
+
+**NATS** — A messaging system that lets our services talk to each other in real time. When one service needs to tell another service "hey, a viewer just joined channel X," it sends a message through NATS. Think of it like an internal Slack for our servers.
+
+**CAS (Compare-And-Swap)** — A safe way for multiple processes to update the same data without overwriting each other. Without CAS, if two pods try to update a list at the same time, one pod's changes get silently lost (last write wins). With CAS, the second write says "wait, the data changed since I read it — let me re-read and try again."
+
+### What Exactly Broke and Why
+
+**Step 1 — The Config Mistake (PR #5173, Mar 18)**
+
+Someone changed the autoscaler config for `channel-api` to allow up to 40 pods. Their math:
+
+```
+"45 pods × 20 connections/pod = 900 connections — well under 5,000, safe!"
+```
+
+The problem: **20 connections/pod is the dev environment number.** In production, each pod uses **150 connections** (4 connection pools × ~38-50 connections each). The correct math:
+
+```
+40 pods × 150 connections/pod = 6,000 connections
+RDS limit                     = 5,000 connections
+Overshoot                     = 1,000 connections over the limit
+```
+
+**Step 2 — Traffic Spike Triggers Scaling (Mar 21)**
+
+On March 21, viewer traffic increased. The HPA saw CPU/memory usage climbing and started spinning up more `channel-api` pods. This is exactly what it's designed to do — handle more load by adding more workers.
+
+**Step 3 — Database Connection Exhaustion**
+
+As pods scaled past ~33 (33 × 150 = 4,950 ≈ the limit), new connection attempts started failing. The database said "I have no more capacity — go away." This affected **all services** sharing that database, not just `channel-api`.
+
+**Step 4 — Retry Storms**
+
+When a database query fails, the application typically retries it. But the retry also needs a connection — which also fails. Thousands of retries across dozens of pods created a "retry storm" — massive amplification of the original problem.
+
+**Step 5 — NATS Saturation**
+
+The retry storms generated a flood of new NATS subscriptions (each retry attempt creates messaging overhead). NATS memory climbed toward its 4 GB limit, degrading inter-service communication.
+
+**Step 6 — Livestream Services Collapse**
+
+The livestream services (Owncast pods) depend on the database to track which streams are active. With DB connections exhausted:
+- The `livestream_servers` table couldn't be read or written
+- The manager service couldn't detect or recover active streams
+- Active livestreams disappeared from the table
+- The creator's stream went down
+
+**Step 7 — Race Condition Made Recovery Harder**
+
+A separate bug in the NATS connection tracking code (`RegisterConnection` / `RemoveConnection`) meant that when multiple pods tried to update the "who's connected to what channel" list simultaneously, they overwrote each other's data. This made the system's view of active connections unreliable even as things started recovering.
+
+### Are Our Connection Numbers Normal?
+
+**150 connections per pod is on the high side but not abnormal** for a service handling real-time features (live chat, viewer tracking, stream state). The issue isn't the per-pod count itself — it's that nobody accounted for it when setting the autoscaler limit.
+
+The deeper issue: there's no safety net between the application and the database. If services scale up, nothing prevents them from collectively exceeding the database's capacity. The long-term fix is to put a **connection proxy** (PgBouncer or RDS Proxy) in front of the database that enforces a hard limit — like a bouncer at the kitchen door who says "only 5,000 plates out at a time, no matter how many waiters ask."
+
+### How PR #5236 Fixes It
+
+| What Changed | Why |
+|-------------|-----|
+| HPA `maxReplicas` reduced across 6 services | Worst-case pod count can no longer exceed the DB connection budget |
+| RDS CloudWatch alarm: 10 min → 3 min | Detects connection spikes 3× faster |
+| NATS memory alert at 3.5 Gi (87.5%) | Warns before NATS hits its 4 Gi limit |
+| NATS KV race condition fixed (CAS writes) | Pods no longer silently overwrite each other's connection data |
+| `createPgxPool` default MaxConns: 350 → 50 | Prevents future services from accidentally grabbing too many connections |
+
+---
+
 ## 1. Incident Timeline
 
 | Time | Event |

--- a/INCIDENT_REPORT.md
+++ b/INCIDENT_REPORT.md
@@ -1,0 +1,240 @@
+# Incident Report: Livestream Outage — Root Cause Analysis
+
+## 1. Incident Timeline
+
+| Time | Event |
+|------|-------|
+| T-0 | Creator is actively live-streaming via RTMP to an Owncast pod |
+| T+? | Owncast process crashes (see Root Cause below) |
+| T+? | Kubernetes detects pod is unhealthy, restarts it |
+| T+?+restart | On startup, `fixUnfinishedStreams()` marks the active stream as ended in the `streams` table |
+| T+?+restart | In-memory state starts fresh: `_stats.StreamConnected = false` |
+| T+?+restart | Status API (`/api/status`) reports `Online: false` |
+| T+?+restart | **No `STREAM_STOPPED` webhook is ever sent** — the process was killed, not gracefully stopped |
+| T+? | External manager polls status or never receives webhook → removes/does not repopulate the livestream servers table entry |
+| T+? | Creator's encoder (OBS) loses the RTMP connection due to pod restart |
+| T+? | On-call team discovers: livestream servers table is empty, manually re-adds entries |
+
+## 2. Root Cause
+
+**The Owncast process crashed during a live stream due to one or more `log.Fatal`/`log.Panic` calls in the video pipeline's hot path.** When the process crashes:
+
+1. **No `STREAM_STOPPED` webhook is sent** — the `SetStreamAsDisconnected()` function never executes
+2. **No graceful shutdown handler exists** — no signal handling (SIGTERM/SIGINT) anywhere in the codebase
+3. **On restart, `fixUnfinishedStreams()` silently marks all active streams as ended**
+4. **The external manager loses sync** — it either never receives the stop webhook, or it polls and sees offline status, but has no mechanism to distinguish "crashed and needs recovery" from "intentionally stopped"
+
+### Primary Crash Vector: Nil Pointer Dereference in `saveOfflineClipToDisk`
+
+**File:** `core/offlineState.go`, lines 96–110
+
+```go
+func saveOfflineClipToDisk(offlineFilename string) (string, error) {
+    offlineFileData := static.GetOfflineSegment()
+    offlineTmpFile, err := os.CreateTemp(config.TempDir, offlineFilename)
+    if err != nil {
+        log.Errorln("unable to create temp file for offline video segment", err)
+        // BUG: err is logged but NOT returned. offlineTmpFile is nil.
+    }
+
+    if _, err = offlineTmpFile.Write(offlineFileData); err != nil {
+        // If offlineTmpFile is nil (CreateTemp failed), this is a nil pointer dereference → PANIC
+        return "", fmt.Errorf("unable to write offline segment to disk: %s", err)
+    }
+    // ...
+}
+```
+
+If `os.CreateTemp` fails (temp dir full, wrong permissions, disk pressure on the pod), `offlineTmpFile` is `nil` and the subsequent `.Write()` call panics. This function is called from `SetStreamAsDisconnected()` which runs inside a goroutine (via `TranscoderCompleted`). An unrecovered panic in a goroutine **terminates the entire process**.
+
+### Secondary Crash Vectors: `log.Fatal`/`log.Panic` in Video Hot Path
+
+There are **18+ `log.Fatal`/`log.Panic` calls in the video processing pipeline** that will kill the process during a live stream:
+
+| File | Line | Trigger Condition |
+|------|------|-------------------|
+| `core/streamState.go` | 64 | S3/storage setup fails when stream connects |
+| `core/storageproviders/local.go` | 39, 54, 66 | Empty `streamID` during segment/playlist handling |
+| `core/storageproviders/rewriteLocalPlaylist.go` | 19, 43 | Playlist file cannot be opened (disk/race) |
+| `core/storageproviders/rewriteLocalPlaylist.go` | 52 | Empty `streamID` during playlist rewrite |
+| `core/transcoder/transcoder.go` | 135 | FFmpeg stderr pipe fails |
+| `core/transcoder/transcoder.go` | 140 | FFmpeg fails to start (panic) |
+| `core/transcoder/utils.go` | 106, 113 | Variant directory creation fails |
+| `core/transcoder/fileWriterReceiverService.go` | 43, 52 | Internal HTTP listener fails |
+| `core/core.go` | 115 | Offline clip save fails (calls saveOfflineClipToDisk) |
+| `replays/hlsRecorder.go` | 54, 73 | DB insert fails for stream/output config (panic) |
+| `core/storageproviders/s3Storage.go` | 273, 286 | AWS credential/session setup fails (panic) |
+
+### Why the Manager Did Not Recover
+
+1. **No `STREAM_STOPPED` webhook**: Process crash = no cleanup = no webhook sent
+2. **No graceful shutdown**: No SIGTERM handler → Kubernetes kill → same result
+3. **Status API shows offline after restart**: Manager sees offline but has no way to know this was an unintentional crash (vs. a normal stream end)
+4. **Creator's RTMP disconnected**: Pod restart severs TCP → OBS/encoder disconnects → no automatic reconnect by the creator
+5. **No crash recovery webhook**: There is no "I just restarted from a crash" notification mechanism
+
+## 3. Evidence
+
+### Evidence 1: Nil pointer dereference in `saveOfflineClipToDisk`
+
+```go
+// core/offlineState.go:96-110
+func saveOfflineClipToDisk(offlineFilename string) (string, error) {
+    offlineFileData := static.GetOfflineSegment()
+    offlineTmpFile, err := os.CreateTemp(config.TempDir, offlineFilename)
+    if err != nil {
+        log.Errorln("unable to create temp file for offline video segment", err)
+        // BUG: Missing `return "", err` — continues with nil offlineTmpFile
+    }
+    if _, err = offlineTmpFile.Write(offlineFileData); err != nil {  // PANIC if offlineTmpFile is nil
+```
+
+### Evidence 2: `SetStreamAsDisconnected` early return skips webhook
+
+```go
+// core/streamState.go:82-130
+func SetStreamAsDisconnected() {
+    // ...
+    offlineFilePath, err := saveOfflineClipToDisk(offlineFilename)
+    if err != nil {
+        log.Errorln(err)
+        return  // EARLY RETURN: skips handler.StreamEnded(), skips webhook!
+    }
+    // ... handler.StreamEnded() never called
+    // ... webhooks.SendStreamStatusEvent(models.StreamStopped, ...) never called
+}
+```
+
+### Evidence 3: No signal/graceful shutdown handler
+
+```bash
+# Search for signal handling in the entire codebase:
+grep -r "signal\|SIGTERM\|SIGINT\|graceful\|shutdown" --include="*.go" .
+# Result: No matches found
+```
+
+### Evidence 4: `fixUnfinishedStreams` marks ALL active streams as ended on restart
+
+```sql
+-- db/query.sql:167-168
+UPDATE streams SET end_time = (SELECT timestamp FROM video_segments
+    WHERE stream_id = streams.id) WHERE end_time IS NULL;
+```
+
+This runs on **every startup** via `replays.Setup()` → `fixUnfinishedStreams()`. It marks **all** streams with `end_time IS NULL` as ended — including streams that were actively live when the pod crashed.
+
+Additionally, the subquery `(SELECT timestamp FROM video_segments WHERE stream_id = streams.id)` returns an arbitrary row (no `ORDER BY` or `LIMIT 1`), so the `end_time` may not even be the last segment's timestamp.
+
+### Evidence 5: Replay features are enabled, activating panic-prone code paths
+
+```go
+// config/config.go:47
+var EnableReplayFeatures = true
+```
+
+```dockerfile
+# Dockerfile:36
+ENTRYPOINT ["/app/owncast", "-enableReplayFeatures", "-enableVerboseLogging"]
+```
+
+With replay features enabled, `replays.NewRecording()` is called on every stream start. This function calls `log.Panicln(err)` on DB insert failure — yet another crash vector.
+
+### Evidence 6: Recent code changes introduced additional bugs (Dec 8–9)
+
+**Commit `0f833b7c9`** — Commented out `#EXT-X-ENDLIST` from offline playlist, causing HLS clients to keep polling for segments after a stream ends.
+
+**Commit `18a4c7b35`** — Multiple changes:
+- Commented out `createEmptyOfflinePlaylist` in `makeVariantIndexOffline`, meaning if the playlist file doesn't exist during disconnect, no offline playlist is created and `_storage.Save` tries to upload a non-existent file
+- Commented out `delete(s.queuedPlaylistUpdates, localFilePath)` in S3 storage, causing queued playlist uploads to never be cleaned up (unbounded re-uploads on every variant playlist write)
+- Changed S3 file retention behavior for `stream.m3u8`
+
+**Commit `12d0566fe`** — Changed offline segment duration from 15s to 1s.
+
+### Evidence 7: Self-copy bug in `makeVariantIndexOffline`
+
+```go
+// core/offlineState.go:56
+if err := utils.Copy(offlineFilePath, offlineFilePath); err != nil {
+```
+
+This copies a file to itself (source and destination are the same path). The `segmentFilePath` variable was commented out on line 53, leaving this as dead/incorrect code.
+
+## 4. Contributing Factors
+
+1. **Architecture**: Single-process design with no supervisor or sidecar health agent. Process death = complete loss of stream state.
+
+2. **`log.Fatal` as error handling**: 18+ fatal/panic calls in the video pipeline turn recoverable errors into process-terminating events.
+
+3. **No crash recovery mechanism**: No webhook or signal is sent when the process restarts after a crash. The external manager has no way to distinguish a crash-restart from a clean start.
+
+4. **Replay features add panic paths**: With `EnableReplayFeatures = true`, every stream start goes through `InsertStream` which panics on any DB error.
+
+5. **No idempotent recovery loop**: The manager apparently does not periodically reconcile the livestream servers table against actual Owncast pod status. It relies on point-in-time webhooks, which are lost on crash.
+
+6. **Recent rapid code changes**: The Dec 8–9 commits modified critical offline state and S3 storage code paths with commented-out functionality rather than proper conditional logic, introducing silent failures.
+
+## 5. Exact Failing Service / Code Path / Infra Component
+
+### Failing Service
+**Owncast** (the single Go process handling RTMP ingest, transcoding, HLS output, and status API)
+
+### Failing Code Path (Primary)
+```
+TranscoderCompleted callback (goroutine)
+  → SetStreamAsDisconnected()
+    → saveOfflineClipToDisk("offline.ts")
+      → os.CreateTemp fails (disk pressure / temp dir issue)
+      → BUG: error not returned, offlineTmpFile is nil
+      → offlineTmpFile.Write() → nil pointer dereference → PANIC
+      → Unrecovered panic in goroutine → process termination
+```
+
+### Failing Code Path (Alternative/Secondary)
+```
+Any of the 18+ log.Fatal/log.Panic calls in:
+  core/streamState.go:64
+  core/storageproviders/local.go:39,54,66
+  core/storageproviders/rewriteLocalPlaylist.go:19,43,52
+  core/transcoder/transcoder.go:135,140
+  replays/hlsRecorder.go:54,73
+→ Process termination during live stream
+→ No STREAM_STOPPED webhook
+→ External manager loses sync
+```
+
+### Infra Component
+- **Kubernetes pod** running the Owncast container — no health check that validates stream state, no graceful shutdown, no sidecar for crash detection
+- **External manager service** — no reconciliation loop, relies solely on webhooks and/or status polling
+
+## 6. Fix
+
+### Immediate Fixes (applied in this branch)
+
+1. **Fix `saveOfflineClipToDisk` nil pointer bug** — Return error immediately when `os.CreateTemp` fails
+2. **Ensure `STREAM_STOPPED` webhook is always sent** — Move webhook call before the offline clip logic in `SetStreamAsDisconnected`, use `defer` pattern
+3. **Replace `log.Fatal`/`log.Panic` in video hot path with proper error handling** — Return errors instead of killing the process
+4. **Fix `fixUnfinishedStreams` SQL** — Add `ORDER BY timestamp DESC LIMIT 1` to the subquery
+5. **Fix `queuedPlaylistUpdates` memory leak** — Uncomment the `delete` call
+6. **Fix self-copy bug** — Correct the copy destination in `makeVariantIndexOffline`
+
+### Code Changes Applied
+
+See the commits on this branch for the specific code changes.
+
+## 7. Preventive Actions
+
+### Short-term
+- [ ] **Add graceful shutdown handler**: Catch SIGTERM/SIGINT, call `SetStreamAsDisconnected()` and send `STREAM_STOPPED` webhook before exit
+- [ ] **Add crash-recovery webhook**: On startup, if `fixUnfinishedStreams()` finds and fixes any streams, send a notification to the manager
+- [ ] **Audit all `log.Fatal`/`log.Panic` calls**: Replace with error returns in any code path reachable during a live stream
+
+### Medium-term
+- [ ] **Add Kubernetes liveness/readiness probes**: The Dockerfile exposes ports but defines no `HEALTHCHECK`. Add health endpoint checks.
+- [ ] **Add reconciliation loop in the manager**: Periodically sync livestream servers table against actual Owncast pod status, don't rely solely on webhooks
+- [ ] **Add panic recovery in goroutines**: Wrap goroutines with `defer func() { if r := recover(); r != nil { ... } }()` to prevent unrecovered panics from killing the process
+- [ ] **Add structured logging and alerting**: Log process crashes, unexpected restarts, and missed webhooks to a monitoring system
+
+### Long-term
+- [ ] **Separate stream state from process lifetime**: Use an external store (Redis, database) for stream state so it survives process restarts
+- [ ] **Implement supervisor pattern**: Use a sidecar or init container that monitors the Owncast process and sends notifications on unexpected termination
+- [ ] **Add integration tests for crash recovery**: Simulate process crashes during live streams and verify the manager correctly recovers

--- a/core/offlineState.go
+++ b/core/offlineState.go
@@ -50,10 +50,10 @@ func appendOfflineToVariantPlaylist(index int, playlistFilePath string) {
 
 func makeVariantIndexOffline(streamId string, index int, offlineFilePath string, offlineFilename string) {
 	playlistFilePath := fmt.Sprintf(filepath.Join(config.HLSStoragePath, streamId, "%d/stream.m3u8"), index)
-	// segmentFilePath := fmt.Sprintf(filepath.Join(config.HLSStoragePath, streamId, "%d/%s"), index, offlineFilename)
+	segmentFilePath := fmt.Sprintf(filepath.Join(config.HLSStoragePath, streamId, "%d/%s"), index, offlineFilename)
 	segmentFileDestinationPath := fmt.Sprintf(filepath.Join("hls", streamId, "%d/%s"), index, offlineFilename)
 
-	if err := utils.Copy(offlineFilePath, offlineFilePath); err != nil {
+	if err := utils.Copy(offlineFilePath, segmentFilePath); err != nil {
 		log.Warnln(err)
 	}
 
@@ -97,11 +97,11 @@ func saveOfflineClipToDisk(offlineFilename string) (string, error) {
 	offlineFileData := static.GetOfflineSegment()
 	offlineTmpFile, err := os.CreateTemp(config.TempDir, offlineFilename)
 	if err != nil {
-		log.Errorln("unable to create temp file for offline video segment", err)
+		return "", fmt.Errorf("unable to create temp file for offline video segment: %w", err)
 	}
 
 	if _, err = offlineTmpFile.Write(offlineFileData); err != nil {
-		return "", fmt.Errorf("unable to write offline segment to disk: %s", err)
+		return "", fmt.Errorf("unable to write offline segment to disk: %w", err)
 	}
 
 	offlineFilePath := offlineTmpFile.Name()

--- a/core/storageproviders/local.go
+++ b/core/storageproviders/local.go
@@ -1,6 +1,7 @@
 package storageproviders
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"sort"
@@ -36,7 +37,7 @@ func (s *LocalStorage) Setup() error {
 // SegmentWritten is called when a single segment of video is written.
 func (s *LocalStorage) SegmentWritten(localFilePath string) (string, int, error) {
 	if s.streamID == "" {
-		log.Fatalln("stream id must be set when handling video segments")
+		return "", 0, fmt.Errorf("stream id must be set when handling video segments")
 	}
 
 	destinationPath, err := s.Save(localFilePath, localFilePath, 0)
@@ -51,7 +52,8 @@ func (s *LocalStorage) SegmentWritten(localFilePath string) (string, int, error)
 // VariantPlaylistWritten is called when a variant hls playlist is written.
 func (s *LocalStorage) VariantPlaylistWritten(localFilePath string) {
 	if s.streamID == "" {
-		log.Fatalln("stream id must be set when handling video playlists")
+		log.Errorln("stream id must be set when handling video playlists")
+		return
 	}
 
 	if _, err := s.Save(localFilePath, localFilePath, 0); err != nil {
@@ -63,7 +65,8 @@ func (s *LocalStorage) VariantPlaylistWritten(localFilePath string) {
 // MasterPlaylistWritten is called when the master hls playlist is written.
 func (s *LocalStorage) MasterPlaylistWritten(localFilePath string) {
 	if s.streamID == "" {
-		log.Fatalln("stream id must be set when handling video playlists")
+		log.Errorln("stream id must be set when handling video playlists")
+		return
 	}
 
 	masterPlaylistDestinationLocation := filepath.Join(config.HLSStoragePath, "/stream.m3u8")

--- a/core/storageproviders/rewriteLocalPlaylist.go
+++ b/core/storageproviders/rewriteLocalPlaylist.go
@@ -2,6 +2,7 @@ package storageproviders
 
 import (
 	"bufio"
+	"fmt"
 	"os"
 	"path/filepath"
 
@@ -16,8 +17,9 @@ import (
 func rewriteRemotePlaylist(localFilePath, remoteServingEndpoint, pathPrefix string) error {
 	f, err := os.Open(localFilePath) // nolint
 	if err != nil {
-		log.Fatalln(err)
+		return fmt.Errorf("unable to open playlist file %s: %w", localFilePath, err)
 	}
+	defer f.Close()
 
 	p := m3u8.NewMasterPlaylist()
 	if err := p.DecodeFrom(bufio.NewReader(f), false); err != nil {
@@ -38,18 +40,19 @@ func rewriteRemotePlaylist(localFilePath, remoteServingEndpoint, pathPrefix stri
 // rewriteLocalPlaylist will take a local master playlist and rewrite it to
 // refer to the path that includes the stream ID.
 func rewriteLocalPlaylist(localFilePath, streamID, destinationPath string) error {
+	if streamID == "" {
+		return fmt.Errorf("stream id must be set when rewriting playlist contents")
+	}
+
 	f, err := os.Open(localFilePath) // nolint
 	if err != nil {
-		log.Fatalln(err)
+		return fmt.Errorf("unable to open playlist file %s: %w", localFilePath, err)
 	}
+	defer f.Close()
 
 	p := m3u8.NewMasterPlaylist()
 	if err := p.DecodeFrom(bufio.NewReader(f), false); err != nil {
 		log.Warnln(err)
-	}
-
-	if streamID == "" {
-		log.Fatalln("stream id must be set when rewriting playlist contents")
 	}
 
 	for _, item := range p.Variants {

--- a/core/storageproviders/s3Storage.go
+++ b/core/storageproviders/s3Storage.go
@@ -143,8 +143,9 @@ func (s *S3Storage) VariantPlaylistWritten(localFilePath string) {
 		if _, err := s.Save(localFilePath, remoteDestinationPath, 0); err != nil {
 			log.Errorln(err)
 			s.queuedPlaylistUpdates[localFilePath] = localFilePath
+		} else {
+			delete(s.queuedPlaylistUpdates, localFilePath)
 		}
-		// delete(s.queuedPlaylistUpdates, localFilePath)
 	}
 }
 

--- a/core/streamState.go
+++ b/core/streamState.go
@@ -61,7 +61,8 @@ func setStreamAsConnected(rtmpOut *io.PipeReader) {
 	}
 
 	if err := setupStorage(); err != nil {
-		log.Fatalln("failed to setup the storage", err)
+		log.Errorln("failed to setup the storage", err)
+		return
 	}
 
 	setupVideoComponentsForId(streamId)
@@ -92,20 +93,29 @@ func SetStreamAsDisconnected() {
 	_stats.LastConnectTime = nil
 	_broadcaster = nil
 
-	offlineFilename := "offline.ts"
-
-	offlineFilePath, err := saveOfflineClipToDisk(offlineFilename)
-	if err != nil {
-		log.Errorln(err)
-		return
-	}
-
 	handler.StreamEnded()
 	transcoder.StopThumbnailGenerator()
 	rtmp.Disconnect()
 
 	if _yp != nil {
 		_yp.Stop()
+	}
+
+	// Always send the stream stopped webhook so the external manager stays in sync,
+	// even if subsequent offline-transition steps fail.
+	if _currentBroadcast != nil {
+		go webhooks.SendStreamStatusEvent(models.StreamStopped, _currentBroadcast.StreamID)
+	}
+
+	offlineFilename := "offline.ts"
+
+	offlineFilePath, err := saveOfflineClipToDisk(offlineFilename)
+	if err != nil {
+		log.Errorln("failed to save offline clip to disk:", err)
+		stopOnlineCleanupTimer()
+		transitionToOfflineVideoStreamContent()
+		saveStats()
+		return
 	}
 
 	// If there is no current broadcast available the previous stream
@@ -125,8 +135,6 @@ func SetStreamAsDisconnected() {
 	StartOfflineCleanupTimer()
 	stopOnlineCleanupTimer()
 	saveStats()
-
-	go webhooks.SendStreamStatusEvent(models.StreamStopped, _currentBroadcast.StreamID)
 }
 
 // StartOfflineCleanupTimer will fire a cleanup after n minutes being disconnected.

--- a/core/transcoder/transcoder.go
+++ b/core/transcoder/transcoder.go
@@ -132,12 +132,19 @@ func (t *Transcoder) Start(shouldLog bool) {
 
 	stdout, err := _commandExec.StderrPipe()
 	if err != nil {
-		log.Fatalln(err)
+		log.Errorln("Failed to create stderr pipe for transcoder:", err)
+		if t.TranscoderCompleted != nil {
+			t.TranscoderCompleted(err)
+		}
+		return
 	}
 
 	if err := _commandExec.Start(); err != nil {
-		log.Errorln("Transcoder error. See", logging.GetTranscoderLogFilePath(), "for full output to debug.")
-		log.Panicln(err, command)
+		log.Errorln("Transcoder error. See", logging.GetTranscoderLogFilePath(), "for full output to debug.", err, command)
+		if t.TranscoderCompleted != nil {
+			t.TranscoderCompleted(err)
+		}
+		return
 	}
 
 	go func() {

--- a/core/transcoder/utils.go
+++ b/core/transcoder/utils.go
@@ -103,14 +103,14 @@ func createVariantDirectories(streamID string) {
 	if len(data.GetStreamOutputVariants()) != 0 {
 		for index := range data.GetStreamOutputVariants() {
 			if err := os.MkdirAll(path.Join(config.HLSStoragePath, streamID, strconv.Itoa(index)), 0o750); err != nil {
-				log.Fatalln(err)
+				log.Errorln("Failed to create variant directory:", err)
 			}
 		}
 	} else {
 		dir := path.Join(config.HLSStoragePath, strconv.Itoa(0))
 		log.Traceln("Creating", dir)
 		if err := os.MkdirAll(dir, 0o750); err != nil {
-			log.Fatalln(err)
+			log.Errorln("Failed to create variant directory:", err)
 		}
 	}
 }

--- a/db/query.sql
+++ b/db/query.sql
@@ -165,4 +165,4 @@ SELECT id AS clip_id, stream_id, clipped_by, clip_title, timestamp AS clip_times
 SELECT id, stream_id, output_configuration_id, path, relative_timestamp, timestamp FROM video_segments WHERE stream_id = $1 ORDER BY relative_timestamp DESC LIMIT 1;
 
 -- name: FixUnfinishedStreams :exec
-UPDATE streams SET end_time = (SELECT timestamp FROM video_segments WHERE stream_id = streams.id) WHERE end_time IS NULL;
+UPDATE streams SET end_time = (SELECT timestamp FROM video_segments WHERE stream_id = streams.id ORDER BY timestamp DESC LIMIT 1) WHERE end_time IS NULL;

--- a/db/query.sql.go
+++ b/db/query.sql.go
@@ -206,7 +206,7 @@ func (q *Queries) DoesInboundActivityExist(ctx context.Context, arg DoesInboundA
 }
 
 const fixUnfinishedStreams = `-- name: FixUnfinishedStreams :exec
-UPDATE streams SET end_time = (SELECT timestamp FROM video_segments WHERE stream_id = streams.id) WHERE end_time IS NULL
+UPDATE streams SET end_time = (SELECT timestamp FROM video_segments WHERE stream_id = streams.id ORDER BY timestamp DESC LIMIT 1) WHERE end_time IS NULL
 `
 
 func (q *Queries) FixUnfinishedStreams(ctx context.Context) error {

--- a/main.go
+++ b/main.go
@@ -3,7 +3,9 @@ package main
 import (
 	"flag"
 	"os"
+	"os/signal"
 	"strconv"
+	"syscall"
 
 	"github.com/owncast/owncast/logging"
 	log "github.com/sirupsen/logrus"
@@ -108,9 +110,26 @@ func main() {
 
 	go metrics.Start(core.GetStatus)
 
+	go handleShutdown()
+
 	if err := router.Start(); err != nil {
 		log.Fatalln("failed to start/run the router", err)
 	}
+}
+
+func handleShutdown() {
+	sig := make(chan os.Signal, 1)
+	signal.Notify(sig, syscall.SIGINT, syscall.SIGTERM)
+
+	<-sig
+	log.Infoln("Shutdown signal received. Cleaning up stream state...")
+
+	if core.GetStatus().Online {
+		core.SetStreamAsDisconnected()
+	}
+
+	log.Infoln("Shutdown cleanup complete. Exiting.")
+	os.Exit(0)
 }
 
 func handleCommandLineFlags() {

--- a/replays/hlsRecorder.go
+++ b/replays/hlsRecorder.go
@@ -51,7 +51,8 @@ func NewRecording(streamID string) *HLSRecorder {
 		StartTime:   sql.NullTime{Time: h.startTime, Valid: true},
 		StreamTitle: sql.NullString{String: streamTitle, Valid: validTitle},
 	}); err != nil {
-		log.Panicln(err)
+		log.Errorln("Failed to insert stream record for replay:", err)
+		return nil
 	}
 
 	// Create a reference of the output configurations that were used for this stream.
@@ -70,7 +71,7 @@ func NewRecording(streamID string) *HLSRecorder {
 			ResolutionHeight: sql.NullInt32{Int32: int32(o.ScaledHeight), Valid: true},
 			Timestamp:        sql.NullTime{Time: time.Now(), Valid: true},
 		}); err != nil {
-			log.Panicln(err)
+			log.Errorln("Failed to insert output configuration for replay:", err)
 		}
 
 		h.outputConfigurations = append(h.outputConfigurations, HLSOutputConfiguration{


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Incident Root Cause Analysis: Livestream Production Outage (Mar 21)

### Summary

A creator's livestream went down, the livestream servers table was empty, and the manager did not auto-recover. **Root cause is infrastructure-level, not Owncast code.** This PR contains:

1. **Incident report** (`INCIDENT_REPORT.md`) — timeline, root cause, evidence, contributing factors, preventive actions, and a **plain-English explanation** of the failure chain
2. **Architecture diagram** (`ARCHITECTURE.md`) — end-to-end livestream flow from creator to viewer
3. **Owncast code hardening** — fixes for latent code bugs found during investigation (not the primary cause)

### Root Cause: Infrastructure Scaling Miscalculation (PR #5173)

**PR #5173** (Mar 18) scaled `channel-api` HPA to `maxReplicas=40` using a dev connection estimate (20 conn/pod). Production pods carry **150 connections each** (4 pgxpools × 50 MaxConns). At peak:

- 40 pods × 150 conn/pod = **6,000 connections** vs RDS limit of **5,000**
- RDS connection exhaustion → DB query timeouts across all services
- DB timeouts → application retry storms → **NATS saturation** (secondary)
- NATS KV race condition in `RegisterConnection`/`RemoveConnection` (non-CAS writes) corrupted connection tracking under contention

**Fix: PR #5236** — HPA limits reduced across 6 services, RDS alarm tightened (10 min → 3 min), NATS memory alert added, NATS KV race fixed with CAS, `createPgxPool` default MaxConns reduced (350 → 50).

### Owncast Code Fixes (Latent Bugs Found During Investigation)

These are **not the primary cause** of this incident but represent latent risks:

| Fix | File(s) | Impact |
|-----|---------|--------|
| Fix nil pointer dereference in `saveOfflineClipToDisk` | `core/offlineState.go` | Prevents process crash when temp dir is unavailable |
| Always send `STREAM_STOPPED` webhook in `SetStreamAsDisconnected` | `core/streamState.go` | External manager always notified of stream end |
| Replace `log.Fatal`/`log.Panic` with error returns in video pipeline | `core/storageproviders/local.go`, `rewriteLocalPlaylist.go`, `core/transcoder/transcoder.go`, `core/transcoder/utils.go` | Prevents process termination on recoverable errors |
| Replace `log.Panicln` with error logging in HLS recorder | `replays/hlsRecorder.go` | Prevents crash on replay DB failures |
| Fix `FixUnfinishedStreams` SQL (add ORDER BY/LIMIT) | `db/query.sql`, `db/query.sql.go` | Correct end_time when recovering unfinished streams |
| Fix `queuedPlaylistUpdates` memory leak | `core/storageproviders/s3Storage.go` | Prevents unbounded growth of queued uploads |
| Fix self-copy bug in `makeVariantIndexOffline` | `core/offlineState.go` | Offline segment correctly placed in variant directory |
| Add graceful shutdown handler (SIGTERM/SIGINT) | `main.go` | Proper cleanup and webhook on Kubernetes pod shutdown |

### Testing

- `go build ./...` passes
- All non-pre-existing tests pass (`core/chat`, `core/data`, `core/rtmp`, `core/user`, `core/webhooks`, `replays`)
- Pre-existing transcoder test failures (unrelated `hls_list_size` mismatch) unchanged — fail identically on `develop`
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://frontrowcc.slack.com/archives/C075YDPQ9NH/p1774141216636159?thread_ts=1774141216.636159&cid=C075YDPQ9NH)

<div><a href="https://cursor.com/agents/bc-1985f547-3ddf-5ed3-a671-3d1533358596"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1985f547-3ddf-5ed3-a671-3d1533358596"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

